### PR TITLE
Add basic RNG, ECS and fixed scheduler

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <canvas id="game"></canvas>
-  <script type="module" src="src/main.js"></script>
+  <script type="module" src="src/main.mjs"></script>
 </body>
 </html>

--- a/src/engine/ecs.js
+++ b/src/engine/ecs.js
@@ -1,8 +1,38 @@
 export function createWorld() {
-  const entities = new Set();
-  return {
-    add(e) { entities.add(e); },
-    remove(e) { entities.delete(e); },
-    forEach(fn) { entities.forEach(fn); }
-  };
+  let nextId = 1;
+  const components = new Map(); // Map of component type -> Map<entity, data>
+
+  function createEntity() {
+    return nextId++;
+  }
+
+  function addComponent(id, type, data) {
+    if (!components.has(type)) components.set(type, new Map());
+    components.get(type).set(id, data);
+  }
+
+  function removeComponent(id, type) {
+    components.get(type)?.delete(id);
+  }
+
+  function query(...types) {
+    if (types.length === 0) return [];
+    const maps = types.map(t => components.get(t));
+    if (maps.some(m => !m)) return [];
+    const [first, ...rest] = maps;
+    const results = [];
+    for (const [id, comp] of first) {
+      const row = [comp];
+      let match = true;
+      for (const m of rest) {
+        const c = m.get(id);
+        if (!c) { match = false; break; }
+        row.push(c);
+      }
+      if (match) results.push({ id, comps: row });
+    }
+    return results;
+  }
+
+  return { createEntity, addComponent, removeComponent, query };
 }

--- a/src/engine/loop.js
+++ b/src/engine/loop.js
@@ -1,12 +1,17 @@
 export function createLoop(step) {
+  const STEP = 1000 / 60; // ms per update
   let last = 0;
+  let acc = 0;
   let running = false;
 
   function frame(t) {
     if (!running) return;
-    const dt = (t - last) / 1000;
+    acc += t - last;
     last = t;
-    step(dt);
+    while (acc >= STEP) {
+      step(STEP);
+      acc -= STEP;
+    }
     requestAnimationFrame(frame);
   }
 
@@ -14,7 +19,7 @@ export function createLoop(step) {
     start() {
       if (!running) {
         running = true;
-        requestAnimationFrame(t => { last = t; frame(t); });
+        requestAnimationFrame(time => { last = time; frame(time); });
       }
     },
     stop() { running = false; }

--- a/src/engine/rng.js
+++ b/src/engine/rng.js
@@ -1,9 +1,21 @@
-export function createRng(seed) {
-  let state = seed >>> 0;
-  return function next() {
-    state = (state + 0x6D2B79F5) | 0;
-    let t = Math.imul(state ^ state >>> 15, 1 | state);
-    t = (t + Math.imul(t ^ t >>> 7, 61 | t)) ^ t;
-    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+export function createRng(seed = 123456789n) {
+  let state = BigInt.asUintN(64, BigInt(seed));
+
+  function next64() {
+    state ^= state >> 12n;
+    state ^= state << 25n;
+    state ^= state >> 27n;
+    state = BigInt.asUintN(64, state * 2685821657736338717n);
+    return state;
+  }
+
+  return {
+    nextInt() {
+      next64();
+      return Number(state & 0xffffffffn);
+    },
+    nextFloat() {
+      return this.nextInt() / 0x100000000;
+    }
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,0 @@
-import { initEngine } from './engine/engine.js';
-
-function boot() {
-  const canvas = document.getElementById('game');
-  initEngine(canvas);
-}
-
-window.addEventListener('DOMContentLoaded', boot);

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,0 +1,25 @@
+import { createRng } from './engine/rng.js';
+import { createWorld } from './engine/ecs.js';
+import { createLoop } from './engine/loop.js';
+
+function boot() {
+  const rng = createRng();
+  const world = createWorld();
+  const loop = createLoop(step);
+
+  let elapsed = 0;
+  let logTimer = 0;
+
+  function step(dt) {
+    elapsed += dt;
+    logTimer += dt;
+    if (logTimer >= 1000) {
+      logTimer -= 1000;
+      console.log(`${Math.round(elapsed)}ms`, rng.nextInt());
+    }
+  }
+
+  loop.start();
+}
+
+window.addEventListener('DOMContentLoaded', boot);


### PR DESCRIPTION
## Summary
- implement xorshift64* RNG for deterministic int/float values
- overhaul ECS to store component maps and add simple querying
- rewrite loop to fixed 60fps scheduler
- add main.mjs using new engine pieces and hook into HTML

## Testing
- `npm test` *(fails: `package.json` missing)*