### PR TITLE
Add sample map and encounter data

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,3 +1,14 @@
 {
-  "encounters": []
+  "encounters": [
+    {
+      "id": "forest_ambush",
+      "title": "Forest Ambush",
+      "text": "Bandits spring from the trees, demanding your supplies.",
+      "choices": [
+        { "option": "Fight", "cost": {"health": 2} },
+        { "option": "Pay them off", "cost": {"food": 3, "water": 2} },
+        { "option": "Flee", "cost": {"stamina": 1} }
+      ]
+    }
+  ]
 }

--- a/data/map.json
+++ b/data/map.json
@@ -1,3 +1,28 @@
 {
-  "waypoints": []
+  "waypoints": [
+    {
+      "name": "Prague",
+      "coords": [0, 0],
+      "neighbors": ["Vienna", "Nuremberg"],
+      "travelCosts": {"food": 2, "water": 1}
+    },
+    {
+      "name": "Vienna",
+      "coords": [5, -3],
+      "neighbors": ["Prague", "Venice"],
+      "travelCosts": {"food": 3, "water": 2}
+    },
+    {
+      "name": "Nuremberg",
+      "coords": [-2, 1],
+      "neighbors": ["Prague"],
+      "travelCosts": {"food": 2, "water": 1}
+    },
+    {
+      "name": "Venice",
+      "coords": [7, -8],
+      "neighbors": ["Vienna"],
+      "travelCosts": {"food": 4, "water": 3}
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- flesh out map.json with sample waypoints and neighbors
- add a sample encounter to events.json

## Testing
- `python3 -m json.tool data/map.json`
- `python3 -m json.tool data/events.json`
