### PR TITLE
Implement map loading and simple rendering

### DIFF
--- a/src/engine/mapLoader.js
+++ b/src/engine/mapLoader.js
@@ -1,0 +1,9 @@
+export async function loadMap(world, url = 'data/map.json') {
+  const res = await fetch(url);
+  const map = await res.json();
+  for (const wp of map.waypoints) {
+    const id = world.createEntity();
+    world.addComponent(id, 'waypoint', wp);
+  }
+  return map;
+}

--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -2,9 +2,28 @@ export function createRenderer(canvas) {
   const ctx = canvas.getContext('2d');
 
   return {
+    ctx,
     clear() {
       ctx.fillStyle = '#000';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
     }
   };
+}
+
+const waypointUrl =
+  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/node_default.png';
+let waypointImg;
+
+export function drawMap(ctx, map) {
+  if (!waypointImg) {
+    waypointImg = new Image();
+    waypointImg.src = waypointUrl;
+  }
+  if (!map) return;
+  for (const wp of map.waypoints) {
+    const [gx, gy] = wp.coords;
+    const x = ctx.canvas.width / 2 + gx * 64 - 32;
+    const y = ctx.canvas.height / 2 + gy * 64 - 32;
+    ctx.drawImage(waypointImg, x, y, 64, 64);
+  }
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,22 +1,26 @@
 import { createRng } from './engine/rng.js';
 import { createWorld } from './engine/ecs.js';
 import { createLoop } from './engine/loop.js';
+import { createRenderer, drawMap } from './engine/renderer.js';
+import { loadMap } from './engine/mapLoader.js';
 
 function boot() {
+  const canvas = document.getElementById('game');
+  canvas.width = 800;
+  canvas.height = 600;
+
   const rng = createRng();
   const world = createWorld();
+  const renderer = createRenderer(canvas);
   const loop = createLoop(step);
 
-  let elapsed = 0;
-  let logTimer = 0;
+  let mapData = null;
 
-  function step(dt) {
-    elapsed += dt;
-    logTimer += dt;
-    if (logTimer >= 1000) {
-      logTimer -= 1000;
-      console.log(`${Math.round(elapsed)}ms`, rng.nextInt());
-    }
+  loadMap(world).then(map => { mapData = map; });
+
+  function step(_dt) {
+    renderer.clear();
+    drawMap(renderer.ctx, mapData);
   }
 
   loop.start();


### PR DESCRIPTION
## Summary
- implement `loadMap` utility to fetch map data and store each waypoint in the ECS
- expand `renderer.js` to expose context and add `drawMap` that draws waypoint icons
- update `main.mjs` to initialize renderer, load the map and render it each frame

## Testing
- `node --version`
- `node --experimental-modules --no-warnings -e "import('./src/main.mjs').then(()=>console.log('ok')).catch(e=>console.error(e))"` *(fails: window is not defined)*