### PR TITLE
Add eachEntity iteration utility

### DIFF
--- a/src/engine/ecs.js
+++ b/src/engine/ecs.js
@@ -1,9 +1,12 @@
 export function createWorld() {
   let nextId = 1;
   const components = new Map(); // Map of component type -> Map<entity, data>
+  const entities = new Set(); // Track created entity ids
 
   function createEntity() {
-    return nextId++;
+    const id = nextId++;
+    entities.add(id);
+    return id;
   }
 
   function addComponent(id, type, data) {
@@ -13,6 +16,12 @@ export function createWorld() {
 
   function removeComponent(id, type) {
     components.get(type)?.delete(id);
+  }
+
+  function eachEntity(callback) {
+    for (const id of entities) {
+      callback(id);
+    }
   }
 
   function query(...types) {
@@ -34,5 +43,5 @@ export function createWorld() {
     return results;
   }
 
-  return { createEntity, addComponent, removeComponent, query };
+  return { createEntity, addComponent, removeComponent, query, eachEntity };
 }

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -11,7 +11,7 @@ export function initEngine(canvas) {
 
   function step(dt) {
     renderer.clear();
-    world.forEach(e => {
+    world.eachEntity(e => {
       // TODO: update and render each entity
     });
   }


### PR DESCRIPTION
## Summary
- track world entity IDs when created
- add `eachEntity(callback)` method for iterating over entities
- use `eachEntity` in `initEngine` instead of nonexistent `forEach`

## Testing
- `node -e "import('./src/engine/engine.js').then(m=>console.log('engine imported'))"`
- `npm test` *(fails: could not find package.json)*