### PR TITLE
Enable neighbor-based travel, apply encounter costs, and add simple inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,9 @@ Each legend unveils organically through events; pursuing one closes others, forc
 ## The Promise  
 When finished, *Pilgrim Outbound* will be a pick-up-and-die-trying browser game:  
 clickable, readable, no installs, but deep enough that veterans will chase perfect runs, dissect seed patterns, and swap campfire stories of the one caravan that almost made it home.
+
+## Current Status
+- Basic map travel with costs and neighbor restrictions
+- Placeholder encounters deduct resources and can trigger game over
+- Early HUD and inventory grid implemented (drag-and-drop only)
+

--- a/src/ui/encounter.js
+++ b/src/ui/encounter.js
@@ -1,3 +1,5 @@
+import { PROVISIONS, WATER } from '../components.js';
+
 let panel;
 
 export function showEncounter(data) {
@@ -5,8 +7,22 @@ export function showEncounter(data) {
   console.log('Encounter:', data);
 }
 
-export function runEncounter(data) {
+export function runEncounter(world, playerId, data, onComplete) {
   if (panel) panel.remove();
+
+  function applyCost(cost) {
+    for (const [key, val] of Object.entries(cost)) {
+      let type = null;
+      if (key === 'food') type = PROVISIONS;
+      else if (key === 'water') type = WATER;
+      if (!type) continue;
+      const res = world.query(type).find(r => r.id === playerId);
+      if (res) {
+        const comp = res.comps[0];
+        comp.amount = Math.max(0, comp.amount - val);
+      }
+    }
+  }
 
   panel = document.createElement('div');
   panel.style.position = 'absolute';
@@ -45,7 +61,9 @@ export function runEncounter(data) {
     btn.textContent = choice.option || choice;
     btn.style.marginRight = '6px';
     btn.addEventListener('click', () => {
+      applyCost(choice.cost || {});
       panel.remove();
+      if (onComplete) onComplete();
     });
     choices.appendChild(btn);
   });

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -1,0 +1,86 @@
+export function createInventory() {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.right = '10px';
+  container.style.bottom = '10px';
+  container.style.display = 'grid';
+  container.style.gridTemplateColumns = 'repeat(6, 64px)';
+  container.style.gridTemplateRows = 'repeat(4, 64px)';
+  container.style.gap = '2px';
+  container.style.zIndex = '2';
+  document.body.appendChild(container);
+
+  const cells = [];
+  for (let i = 0; i < 24; i++) {
+    const cell = document.createElement('div');
+    cell.style.width = '64px';
+    cell.style.height = '64px';
+    cell.style.border = '1px solid #555';
+    cell.style.boxSizing = 'border-box';
+    cell.style.position = 'relative';
+    container.appendChild(cell);
+    cells.push(cell);
+  }
+
+  let dragging = null;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  function onDrag(ev) {
+    if (!dragging) return;
+    dragging.style.left = ev.pageX - offsetX + 'px';
+    dragging.style.top = ev.pageY - offsetY + 'px';
+  }
+
+  function onDrop(ev) {
+    if (!dragging) return;
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', onDrop);
+    dragging.style.pointerEvents = 'auto';
+    const cell = cells.find(c => {
+      const r = c.getBoundingClientRect();
+      return (
+        ev.clientX >= r.left &&
+        ev.clientX < r.right &&
+        ev.clientY >= r.top &&
+        ev.clientY < r.bottom
+      );
+    });
+    if (cell) {
+      cell.appendChild(dragging);
+      dragging.style.left = '8px';
+      dragging.style.top = '8px';
+    }
+    dragging = null;
+  }
+
+  function makeItem(color) {
+    const item = document.createElement('div');
+    item.style.width = '48px';
+    item.style.height = '48px';
+    item.style.background = color;
+    item.style.position = 'absolute';
+    item.style.left = '8px';
+    item.style.top = '8px';
+    item.addEventListener('mousedown', ev => {
+      dragging = item;
+      offsetX = ev.offsetX + 8;
+      offsetY = ev.offsetY + 8;
+      item.style.pointerEvents = 'none';
+      document.addEventListener('mousemove', onDrag);
+      document.addEventListener('mouseup', onDrop);
+    });
+    return item;
+  }
+
+  // placeholder items
+  cells[0].appendChild(makeItem('#c0352b'));
+  cells[1].appendChild(makeItem('#44a167'));
+
+  return {
+    element: container,
+    destroy() {
+      container.remove();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- restrict travel to adjacent waypoints and highlight neighbors
- deduct encounter choice costs from player stats
- game-over when provisions or water reach zero
- begin drag-and-drop saddlebag inventory grid
- document current project status

## Testing
- `npm test` *(fails: Could not read package.json)*