### PR TITLE
Add waypoint sprites and courier marker

### DIFF
--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -10,20 +10,65 @@ export function createRenderer(canvas) {
   };
 }
 
-const waypointUrl =
-  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/node_default.png';
-let waypointImg;
+const baseUrl =
+  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/';
 
-export function drawMap(ctx, map) {
+const waypointUrl = `${baseUrl}node_default.png`;
+const currentUrl = `${baseUrl}node_current.png`;
+const visitedUrl = `${baseUrl}node_visited.png`;
+const markerUrl = `${baseUrl}marker.png`;
+const shadowUrl = `${baseUrl}marker_shadow.png`;
+
+let waypointImg;
+let currentImg;
+let visitedImg;
+let markerImg;
+let shadowImg;
+
+export function drawMap(ctx, map, playerPos = null) {
   if (!waypointImg) {
     waypointImg = new Image();
     waypointImg.src = waypointUrl;
   }
+  if (!currentImg) {
+    currentImg = new Image();
+    currentImg.src = currentUrl;
+  }
+  if (!visitedImg) {
+    visitedImg = new Image();
+    visitedImg.src = visitedUrl;
+  }
+  if (!markerImg) {
+    markerImg = new Image();
+    markerImg.src = markerUrl;
+  }
+  if (!shadowImg) {
+    shadowImg = new Image();
+    shadowImg.src = shadowUrl;
+  }
   if (!map) return;
+
+  ctx.imageSmoothingEnabled = false;
+
   for (const wp of map.waypoints) {
     const [gx, gy] = wp.coords;
     const x = ctx.canvas.width / 2 + gx * 64 - 32;
     const y = ctx.canvas.height / 2 + gy * 64 - 32;
-    ctx.drawImage(waypointImg, x, y, 64, 64);
+
+    let img = waypointImg;
+    if (playerPos && gx === playerPos.x && gy === playerPos.y) {
+      img = currentImg;
+    } else if (wp.visited) {
+      img = visitedImg;
+    }
+
+    ctx.drawImage(img, x, y, 64, 64);
+  }
+
+  if (playerPos) {
+    const baseX = ctx.canvas.width / 2 + playerPos.x * 64 - 32;
+    const baseY = ctx.canvas.height / 2 + playerPos.y * 64 - 32;
+    ctx.drawImage(shadowImg, baseX + 32 - 8, baseY + 48, 16, 16);
+    ctx.drawImage(markerImg, baseX + 8, baseY + 8, 48, 48);
   }
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -85,6 +85,9 @@ function boot() {
       pos.y = y;
     }
 
+    // Mark waypoint as visited
+    wp.visited = true;
+
     if (eventsData && eventsData.encounters && eventsData.encounters.length) {
       const idx = Math.floor(rng.nextFloat() * eventsData.encounters.length);
       runEncounter(world, player, eventsData.encounters[idx], checkGameOver);
@@ -96,13 +99,21 @@ function boot() {
 
   loadMap(world).then(map => {
     mapData = map;
+    const posRes = world.query(POSITION).find(r => r.id === player);
+    if (posRes) {
+      const { x, y } = posRes.comps[0];
+      const start = mapData.waypoints.find(w => w.coords[0] === x && w.coords[1] === y);
+      if (start) start.visited = true;
+    }
     mapUI = createMapUI(canvas, mapData, world, player, travelTo);
     mapUI.update();
   });
 
   function step(_dt) {
     renderer.clear();
-    drawMap(renderer.ctx, mapData);
+    const posRes = world.query(POSITION).find(r => r.id === player);
+    const pos = posRes ? posRes.comps[0] : null;
+    drawMap(renderer.ctx, mapData, pos);
     hud.draw(renderer.ctx);
   }
 


### PR DESCRIPTION
## Summary
- load additional sprite assets for map rendering
- highlight visited and current nodes in the map
- draw the courier marker at the player's position
- mark waypoints as visited when reached and on map load
- update `drawMap` call site to provide player position

## Testing
- `git status --short`