### PR TITLE
Add title screen and enable method

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -7,6 +7,7 @@ import { createMapUI } from './ui/mapUI.js';
 import { runEncounter } from './ui/encounter.js';
 import { createDiary } from './ui/diary.js';
 import { createInventory } from './ui/inventory.js';
+import { createTitleScreen } from './ui/titleScreen.js';
 import {
   POSITION,
   PROVISIONS,
@@ -29,7 +30,7 @@ import {
 } from './components.js';
 import { createHud } from './ui/hud.js';
 
-function boot() {
+function startGame() {
   const canvas = document.getElementById('game');
   canvas.width = 800;
   canvas.height = 600;
@@ -165,7 +166,9 @@ function boot() {
       }
     }
     mapUI = createMapUI(canvas, mapData, world, player, travelTo);
+    mapUI.disable();
     mapUI.update();
+    mapUI.enable();
   });
 
   function step(_dt) {
@@ -177,6 +180,10 @@ function boot() {
   }
 
   loop.start();
+}
+
+function boot() {
+  createTitleScreen(startGame);
 }
 
 window.addEventListener('DOMContentLoaded', boot);

--- a/src/ui/mapUI.js
+++ b/src/ui/mapUI.js
@@ -104,6 +104,7 @@ export function createMapUI(canvas, mapData, world, playerId, onTravel) {
   return {
     update: updateHighlights,
     disable() { enabled = false; highlightLayer.innerHTML = ''; overlay.style.display = 'none'; },
+    enable() { enabled = true; updateHighlights(); },
     destroy() {
       canvas.removeEventListener('mousemove', onMove);
       canvas.removeEventListener('click', onClick);

--- a/src/ui/titleScreen.js
+++ b/src/ui/titleScreen.js
@@ -1,0 +1,38 @@
+export function createTitleScreen(onStart) {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  overlay.style.left = '0';
+  overlay.style.top = '0';
+  overlay.style.width = '100%';
+  overlay.style.height = '100%';
+  overlay.style.background = 'rgba(0, 0, 0, 0.85)';
+  overlay.style.color = '#fff';
+  overlay.style.display = 'flex';
+  overlay.style.flexDirection = 'column';
+  overlay.style.justifyContent = 'center';
+  overlay.style.alignItems = 'center';
+  overlay.style.zIndex = '1000';
+
+  const title = document.createElement('h1');
+  title.textContent = 'Pilgrim Outbound';
+  overlay.appendChild(title);
+
+  const flavor = document.createElement('p');
+  flavor.textContent = 'A lone courier rides into the unknown.';
+  flavor.style.marginBottom = '16px';
+  overlay.appendChild(flavor);
+
+  const startBtn = document.createElement('button');
+  startBtn.textContent = 'Start Journey';
+  startBtn.addEventListener('click', () => {
+    overlay.remove();
+    if (onStart) onStart();
+  });
+  overlay.appendChild(startBtn);
+
+  document.body.appendChild(overlay);
+
+  return {
+    destroy() { overlay.remove(); }
+  };
+}


### PR DESCRIPTION
## Summary
- add a title screen overlay shown on load
- add `enable()` to `mapUI`
- initialize the world in `startGame()` and show the title screen on DOM ready

## Testing
- `npm test` *(fails: ENOENT no package.json)*