### PR TITLE
Add harvest sites and menu

### DIFF
--- a/data/map.json
+++ b/data/map.json
@@ -13,7 +13,8 @@
       "travelCosts": {
         "food": 2,
         "water": 1
-      }
+      },
+      "sites": ["farm", "forest"]
     },
     {
       "name": "Vienna",
@@ -28,7 +29,8 @@
       "travelCosts": {
         "food": 3,
         "water": 2
-      }
+      },
+      "sites": ["farm", "river"]
     },
     {
       "name": "Nuremberg",
@@ -42,7 +44,8 @@
       "travelCosts": {
         "food": 2,
         "water": 1
-      }
+      },
+      "sites": ["forest"]
     },
     {
       "name": "Venice",
@@ -56,7 +59,8 @@
       "travelCosts": {
         "food": 4,
         "water": 3
-      }
+      },
+      "sites": ["river"]
     },
     {
       "name": "Rome",
@@ -70,7 +74,8 @@
       "travelCosts": {
         "food": 4,
         "water": 3
-      }
+      },
+      "sites": ["farm", "mine"]
     }
   ]
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -10,6 +10,7 @@ import { createInventory } from './ui/inventory.js';
 // Keep both imports:
 import { createTitleScreen } from './ui/titleScreen.js';
 import { createResourceMenu } from './ui/resourceMenu.js';
+import { createHarvestMenu } from './ui/harvestMenu.js';
 
 import {
   POSITION,
@@ -20,10 +21,13 @@ import {
   SILVER,
   WOOD,
   FORTUNE,
+  STAMINA,
   FLAGS,
   addPosition,
   addProvisions,
   addWater,
+  addHealth,
+  addStamina,
   addGear,
   addIron,
   addSilver,
@@ -51,6 +55,7 @@ function startGame() {
   let eventsData = null;
   let inventory = null;
   let resources = null;
+  let harvest = null;
   let gameOver = false;
 
   const player = world.createEntity();
@@ -71,6 +76,7 @@ function startGame() {
   inventory.hide();
   resources = createResourceMenu(world, player);
   resources.update();
+  harvest = createHarvestMenu(world, player);
 
   // A button to toggle the resource menu
   const resBtn = document.createElement('button');
@@ -114,6 +120,8 @@ function startGame() {
 
   function travelTo(wp) {
     console.log('Traveling to', wp.name);
+
+    if (harvest) harvest.hide();
 
     // Spend provisions and water according to travel costs
     const costs = wp.travelCosts || { food: 0, water: 0 };
@@ -179,6 +187,7 @@ function startGame() {
 
       const next = () => {
         if (!queue.length) {
+          if (harvest && wp.sites) harvest.show(wp.sites);
           checkGameOver();
           return;
         }
@@ -186,6 +195,7 @@ function startGame() {
         runEncounter(world, player, ev, diary.add, next);
       };
       if (queue.length) next();
+      else if (harvest && wp.sites) harvest.show(wp.sites);
     }
 
     if (mapUI) mapUI.update();

--- a/src/ui/harvestMenu.js
+++ b/src/ui/harvestMenu.js
@@ -1,0 +1,94 @@
+import {
+  PROVISIONS,
+  WATER,
+  GEAR,
+  IRON,
+  WOOD,
+  STAMINA
+} from '../components.js';
+
+export function createHarvestMenu(world, playerId) {
+  const panel = document.createElement('div');
+  panel.style.position = 'absolute';
+  panel.style.left = '50%';
+  panel.style.top = '50%';
+  panel.style.transform = 'translate(-50%, -50%)';
+  panel.style.background = 'rgba(0, 0, 0, 0.85)';
+  panel.style.color = '#fff';
+  panel.style.padding = '8px';
+  panel.style.border = '2px solid #d7a13b';
+  panel.style.zIndex = '1000';
+  panel.style.display = 'none';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Harvest';
+  panel.appendChild(title);
+
+  const list = document.createElement('div');
+  panel.appendChild(list);
+
+  const close = document.createElement('button');
+  close.textContent = 'Close';
+  close.style.marginTop = '8px';
+  close.addEventListener('click', () => hide());
+  panel.appendChild(close);
+
+  document.body.appendChild(panel);
+
+  const RES_MAP = {
+    food: PROVISIONS,
+    water: WATER,
+    gear: GEAR,
+    iron: IRON,
+    wood: WOOD,
+    stamina: STAMINA
+  };
+
+  const SITE_DATA = {
+    farm: { cost: { stamina: 5 }, gain: { food: 5 } },
+    forest: { cost: { stamina: 5 }, gain: { wood: 5 } },
+    river: { cost: { stamina: 5 }, gain: { water: 5 } },
+    mine: { cost: { stamina: 5, gear: 1 }, gain: { iron: 3 } }
+  };
+
+  function modify(type, delta) {
+    const res = world.query(type).find(r => r.id === playerId);
+    if (res) {
+      const comp = res.comps[0];
+      comp.amount = Math.max(0, (comp.amount || 0) + delta);
+    }
+  }
+
+  function apply(site) {
+    const data = SITE_DATA[site];
+    if (!data) return;
+    for (const [k, v] of Object.entries(data.cost || {})) {
+      const type = RES_MAP[k];
+      if (type) modify(type, -v);
+    }
+    for (const [k, v] of Object.entries(data.gain || {})) {
+      const type = RES_MAP[k];
+      if (type) modify(type, v);
+    }
+  }
+
+  function show(sites = []) {
+    list.innerHTML = '';
+    for (const site of sites) {
+      const btn = document.createElement('button');
+      btn.textContent = `Harvest ${site}`;
+      btn.style.display = 'block';
+      btn.style.marginBottom = '4px';
+      btn.addEventListener('click', () => apply(site));
+      list.appendChild(btn);
+    }
+    panel.style.display = 'block';
+  }
+
+  function hide() {
+    panel.style.display = 'none';
+  }
+
+  return { element: panel, show, hide };
+}
+


### PR DESCRIPTION
## Summary
- extend map waypoints with `sites`
- add harvest menu for gathering resources
- trigger harvest menu at waypoints after encounters resolve

## Testing
- `npm test` *(fails: could not find package.json)*