### PR TITLE
Add combat flags and encounter filtering

### DIFF
--- a/src/ui/encounter.js
+++ b/src/ui/encounter.js
@@ -96,7 +96,15 @@ export function runEncounter(world, playerId, data, diaryFn, onComplete) {
   const choices = document.createElement('div');
   choices.style.marginTop = '8px';
 
-  const opts = (data.options || []).slice(0, 3);
+  const flagRes = world.query(FLAGS).find(r => r.id === playerId);
+  const playerFlags = flagRes ? flagRes.comps[0] : {};
+
+  const opts = (data.options || [])
+    .filter(o => {
+      const req = o.outcome?.requiresFlag;
+      return !req || playerFlags[req];
+    })
+    .slice(0, 3);
 
   opts.forEach(choice => {
     const btn = document.createElement('button');


### PR DESCRIPTION
## Summary
- add built-in combat encounters for `bandit_ambush` and `blood_oath`
- show combat encounters before random events when traveling
- display inventory after encounters at a node
- filter encounter options by `requiresFlag`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/main.mjs`
- `node --check src/ui/encounter.js`