### PR TITLE
Add boot sequence and seed init

### DIFF
--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -10,16 +10,12 @@ export function createRenderer(canvas) {
   };
 }
 
-const baseUrl =
-  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/';
-
-const waypointUrl = `${baseUrl}node_default.png`;
-const currentUrl = `${baseUrl}node_current.png`;
-const visitedUrl = `${baseUrl}node_visited.png`;
-const markerUrl = `${baseUrl}marker.png`;
-const shadowUrl = `${baseUrl}marker_shadow.png`;
-const worldMapUrl =
-  'https://cdn.glitch.global/d2170d50-99c2-4bff-b832-8d66b4d6e1f9/D217F327-6759-4EAC-9371-783E96C6D07B.png?v=1748360813466';
+const waypointUrl = 'PASTE_URL_HERE';
+const currentUrl = 'PASTE_URL_HERE';
+const visitedUrl = 'PASTE_URL_HERE';
+const markerUrl = 'PASTE_URL_HERE';
+const shadowUrl = 'PASTE_URL_HERE';
+const worldMapUrl = 'PASTE_URL_HERE';
 
 let waypointImg;
 let currentImg;
@@ -83,4 +79,18 @@ export function drawMap(ctx, map, playerPos = null) {
     ctx.drawImage(shadowImg, baseX + 32 - 8, baseY + 48, 16, 16);
     ctx.drawImage(markerImg, baseX + 8, baseY + 8, 48, 48);
   }
+
+  // subtle radial vignette
+  const g = ctx.createRadialGradient(
+    ctx.canvas.width / 2,
+    ctx.canvas.height / 2,
+    0,
+    ctx.canvas.width / 2,
+    ctx.canvas.height / 2,
+    Math.max(ctx.canvas.width, ctx.canvas.height) / 2
+  );
+  g.addColorStop(0, 'rgba(0,0,0,0)');
+  g.addColorStop(1, 'rgba(0,0,0,0.4)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 }

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -1,0 +1,14 @@
+export function createGameState(seed) {
+  return {
+    seed,
+    day: 1,
+    meters: { food: 140, water: 140, gear: 100 },
+    fortune: 0,
+    flags: {},
+    lexicon: new Set(),
+    recipes: new Set(),
+    inventory: Array(24).fill(null),
+    diary: []
+  };
+}
+

--- a/src/ui/diary.js
+++ b/src/ui/diary.js
@@ -1,16 +1,34 @@
-export function createDiary() {
+export function createDiary(state = null) {
+  const panel = document.createElement('div');
+  panel.id = 'diary';
+  panel.style.position = 'absolute';
+  panel.style.right = '0';
+  panel.style.top = '0';
+  panel.style.width = '250px';
+  panel.style.height = '100%';
+  panel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  panel.style.backgroundSize = 'cover';
+  panel.style.transform = 'translateX(100%)';
+  panel.style.transition = 'transform 0.3s ease-out';
+  panel.style.overflow = 'hidden';
+  panel.style.display = 'flex';
+  panel.style.flexDirection = 'column';
+
   const log = document.createElement('div');
-  log.id = 'diary';
-  log.style.position = 'absolute';
-  log.style.left = '0';
-  log.style.bottom = '0';
-  log.style.width = '100%';
-  log.style.maxHeight = '150px';
+  log.style.flex = '1';
   log.style.overflowY = 'auto';
-  log.style.background = 'rgba(244,241,233,0.85)';
+  log.style.padding = '8px';
   log.style.font = '14px sans-serif';
-  log.style.padding = '4px';
-  document.body.appendChild(log);
+  panel.appendChild(log);
+
+  document.body.appendChild(panel);
+
+  function slideIn() {
+    panel.style.transform = 'translateX(0)';
+    setTimeout(() => {
+      panel.style.transform = 'translateX(100%)';
+    }, 2000);
+  }
 
   return {
     add(line) {
@@ -18,8 +36,12 @@ export function createDiary() {
       p.textContent = line;
       log.appendChild(p);
       log.scrollTop = log.scrollHeight;
+      slideIn();
+      if (state && Array.isArray(state.diary)) {
+        state.diary.push(line);
+      }
     },
-    element: log,
-    destroy() { log.remove(); }
+    element: panel,
+    destroy() { panel.remove(); }
   };
 }

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -4,10 +4,8 @@ import { PROVISIONS, WATER, GEAR, FORTUNE } from '../components.js';
 const healthIcon = '❤';
 const staminaIcon = '⚡';
 
-const foodUrl =
-  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/grain_sack_1x1.png';
-const waterUrl =
-  'https://cdn.glitch.global/813b10b4-5e9c-4e7c-9356-9c7f504e5ff1/water_drop.png';
+const foodUrl = 'PASTE_URL_HERE';
+const waterUrl = 'PASTE_URL_HERE';
 
 let foodImg;
 let waterImg;

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -1,4 +1,4 @@
-export function createInventory() {
+export function createInventory(starterItems = []) {
   const container = document.createElement('div');
   container.style.position = 'absolute';
   container.style.right = '10px';
@@ -55,28 +55,28 @@ export function createInventory() {
     dragging = null;
   }
 
-  function makeItem(color) {
-    const item = document.createElement('div');
-    item.style.width = '48px';
-    item.style.height = '48px';
-    item.style.background = color;
-    item.style.position = 'absolute';
-    item.style.left = '8px';
-    item.style.top = '8px';
-    item.addEventListener('mousedown', ev => {
-      dragging = item;
+
+  // populate starter items if provided
+  starterItems.forEach((item, idx) => {
+    const cell = cells[idx];
+    if (!cell) return;
+    const img = new Image();
+    img.src = 'PASTE_URL_HERE';
+    img.style.width = '48px';
+    img.style.height = '48px';
+    img.style.position = 'absolute';
+    img.style.left = '8px';
+    img.style.top = '8px';
+    img.addEventListener('mousedown', ev => {
+      dragging = img;
       offsetX = ev.offsetX + 8;
       offsetY = ev.offsetY + 8;
-      item.style.pointerEvents = 'none';
+      img.style.pointerEvents = 'none';
       document.addEventListener('mousemove', onDrag);
       document.addEventListener('mouseup', onDrop);
     });
-    return item;
-  }
-
-  // placeholder items
-  cells[0].appendChild(makeItem('#c0352b'));
-  cells[1].appendChild(makeItem('#44a167'));
+    cell.appendChild(img);
+  });
 
   function show() {
     container.style.display = 'grid';

--- a/src/ui/titleScreen.js
+++ b/src/ui/titleScreen.js
@@ -1,36 +1,71 @@
-export function createTitleScreen(onStart) {
+export function createTitleScreen(onRide) {
   const overlay = document.createElement('div');
   overlay.style.position = 'absolute';
   overlay.style.left = '0';
   overlay.style.top = '0';
   overlay.style.width = '100%';
   overlay.style.height = '100%';
-  overlay.style.background = 'rgba(0, 0, 0, 0.85)';
-  overlay.style.color = '#fff';
+  overlay.style.backgroundImage = "url('PASTE_URL_HERE')";
+  overlay.style.backgroundSize = 'cover';
   overlay.style.display = 'flex';
   overlay.style.flexDirection = 'column';
   overlay.style.justifyContent = 'center';
   overlay.style.alignItems = 'center';
   overlay.style.zIndex = '1000';
+  overlay.style.opacity = '1';
+  overlay.style.transition = 'opacity 0.5s';
 
-  const title = document.createElement('h1');
-  title.textContent = 'Pilgrim Outbound';
-  overlay.appendChild(title);
+  const titleImg = new Image();
+  titleImg.src = 'PASTE_URL_HERE';
+  titleImg.style.marginBottom = '16px';
+  overlay.appendChild(titleImg);
 
-  const flavor = document.createElement('p');
-  flavor.textContent = 'A lone courier rides into the unknown.';
-  flavor.style.marginBottom = '16px';
-  overlay.appendChild(flavor);
-
-  const startBtn = document.createElement('button');
-  startBtn.textContent = 'Start Journey';
-  startBtn.addEventListener('click', () => {
-    overlay.remove();
-    if (onStart) onStart();
+  const beginBtn = document.createElement('button');
+  beginBtn.textContent = 'Begin Journey';
+  beginBtn.style.transition = 'filter 0.2s';
+  beginBtn.addEventListener('mouseover', () => {
+    beginBtn.style.filter = 'brightness(1.2)';
   });
-  overlay.appendChild(startBtn);
+  beginBtn.addEventListener('mouseout', () => {
+    beginBtn.style.filter = 'brightness(1)';
+  });
 
+  const seedPanel = document.createElement('div');
+  seedPanel.style.position = 'absolute';
+  seedPanel.style.left = '50%';
+  seedPanel.style.top = '50%';
+  seedPanel.style.transform = 'translate(-50%, -50%)';
+  seedPanel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  seedPanel.style.backgroundSize = 'cover';
+  seedPanel.style.padding = '16px';
+  seedPanel.style.display = 'none';
+
+  const seedInput = document.createElement('input');
+  seedInput.placeholder = 'Run Seed (optional)';
+  seedInput.style.display = 'block';
+  seedInput.style.marginBottom = '8px';
+  seedPanel.appendChild(seedInput);
+
+  const rideBtn = document.createElement('button');
+  rideBtn.textContent = 'Ride';
+  rideBtn.addEventListener('click', () => {
+    const seed = seedInput.value.trim();
+    overlay.style.opacity = '0';
+    setTimeout(() => {
+      overlay.remove();
+      if (onRide) onRide(seed);
+    }, 500);
+  });
+  seedPanel.appendChild(rideBtn);
+
+  overlay.appendChild(beginBtn);
+  overlay.appendChild(seedPanel);
   document.body.appendChild(overlay);
+
+  beginBtn.addEventListener('click', () => {
+    beginBtn.style.display = 'none';
+    seedPanel.style.display = 'block';
+  });
 
   return {
     destroy() { overlay.remove(); }


### PR DESCRIPTION
## Summary
- implement new title screen with seed overlay
- track game state with initial meters and starter items
- slide-in diary panel and log opening entry
- draw world map using placeholder image URLs with vignette overlay
- update inventory, HUD, and renderer to use placeholders

## Testing
- `node --check src/main.mjs`
- `node --check src/ui/titleScreen.js`
- `node --check src/ui/diary.js`
- `node --check src/ui/inventory.js`
- `node --check src/engine/renderer.js`
- `node --check src/gameState.js`