### PR TITLE
Implement travel interactions, resource drains and death panel

### DIFF
--- a/data/map.json
+++ b/data/map.json
@@ -14,7 +14,8 @@
         "food": 2,
         "water": 1
       },
-      "sites": ["farm", "forest"]
+      "sites": ["farm", "forest"],
+      "tags": ["safe camp"]
     },
     {
       "name": "Vienna",
@@ -30,7 +31,8 @@
         "food": 3,
         "water": 2
       },
-      "sites": ["farm", "river"]
+      "sites": ["farm", "river"],
+      "tags": []
     },
     {
       "name": "Nuremberg",
@@ -45,7 +47,8 @@
         "food": 2,
         "water": 1
       },
-      "sites": ["forest"]
+      "sites": ["forest"],
+      "tags": ["shortcut"]
     },
     {
       "name": "Venice",
@@ -60,7 +63,8 @@
         "food": 4,
         "water": 3
       },
-      "sites": ["river"]
+      "sites": ["river"],
+      "tags": ["coastal"]
     },
     {
       "name": "Rome",
@@ -75,7 +79,8 @@
         "food": 4,
         "water": 3
       },
-      "sites": ["farm", "mine"]
+      "sites": ["farm", "mine"],
+      "tags": ["coastal", "legend_marker"]
     }
   ]
 }

--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -24,7 +24,7 @@ let markerImg;
 let shadowImg;
 let worldMapImg;
 
-export function drawMap(ctx, map, playerPos = null) {
+export function drawMap(ctx, map, playerPos = null, tween = null) {
   if (!waypointImg) {
     waypointImg = new Image();
     waypointImg.src = waypointUrl;
@@ -74,8 +74,14 @@ export function drawMap(ctx, map, playerPos = null) {
   }
 
   if (playerPos) {
-    const baseX = ctx.canvas.width / 2 + playerPos.x * 64 - 32;
-    const baseY = ctx.canvas.height / 2 + playerPos.y * 64 - 32;
+    let px = playerPos.x;
+    let py = playerPos.y;
+    if (tween) {
+      px = tween.start.x + (tween.end.x - tween.start.x) * tween.progress;
+      py = tween.start.y + (tween.end.y - tween.start.y) * tween.progress;
+    }
+    const baseX = ctx.canvas.width / 2 + px * 64 - 32;
+    const baseY = ctx.canvas.height / 2 + py * 64 - 32;
     ctx.drawImage(shadowImg, baseX + 32 - 8, baseY + 48, 16, 16);
     ctx.drawImage(markerImg, baseX + 8, baseY + 8, 48, 48);
   }

--- a/src/ui/deathScreen.js
+++ b/src/ui/deathScreen.js
@@ -1,0 +1,25 @@
+export function createDeathScreen(onRestart) {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  overlay.style.left = '0';
+  overlay.style.top = '0';
+  overlay.style.width = '100%';
+  overlay.style.height = '100%';
+  overlay.style.background = "rgba(0,0,0,0.8) url('PASTE_URL_HERE') center/cover no-repeat";
+  overlay.style.display = 'flex';
+  overlay.style.flexDirection = 'column';
+  overlay.style.justifyContent = 'center';
+  overlay.style.alignItems = 'center';
+  overlay.style.zIndex = '10000';
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Restart';
+  btn.addEventListener('click', () => {
+    overlay.remove();
+    if (onRestart) onRestart();
+  });
+  overlay.appendChild(btn);
+
+  document.body.appendChild(overlay);
+  return { remove: () => overlay.remove() };
+}

--- a/src/ui/travelConfirm.js
+++ b/src/ui/travelConfirm.js
@@ -1,10 +1,9 @@
 export function createTravelConfirm() {
   const panel = document.createElement('div');
   panel.style.position = 'absolute';
-  panel.style.left = '50%';
-  panel.style.top = '50%';
-  panel.style.transform = 'translate(-50%, -50%)';
-  panel.style.background = 'rgba(0, 0, 0, 0.85)';
+  panel.style.right = '10px';
+  panel.style.bottom = '10px';
+  panel.style.background = "url('PASTE_URL_HERE') no-repeat center/contain";
   panel.style.color = '#fff';
   panel.style.padding = '8px';
   panel.style.border = '2px solid #d7a13b';
@@ -34,10 +33,12 @@ export function createTravelConfirm() {
   document.body.appendChild(panel);
 
   let confirmFn = null;
+  let cancelFn = null;
 
   function hide() {
     panel.style.display = 'none';
     confirmFn = null;
+    cancelFn = null;
   }
 
   confirmBtn.addEventListener('click', () => {
@@ -46,13 +47,14 @@ export function createTravelConfirm() {
     if (fn) fn();
   });
 
-  cancelBtn.addEventListener('click', hide);
+  cancelBtn.addEventListener('click', () => { hide(); if (cancelFn) cancelFn(); });
 
-  function show(wp, onConfirm) {
+  function show(wp, costs, onConfirm, onCancel, enabled = true) {
     nameEl.textContent = wp.name;
-    const costs = wp.travelCosts || { food: 0, water: 0 };
     costEl.textContent = `Food ${costs.food || 0}, Water ${costs.water || 0}`;
     confirmFn = onConfirm;
+    cancelFn = onCancel;
+    confirmBtn.disabled = !enabled;
     panel.style.display = 'block';
   }
 


### PR DESCRIPTION
## Summary
- add waypoint tags in map data
- show node tooltip with cost and tags
- highlight travel path with line and confirm button
- apply travel cost modifiers and animate courier marker
- check for starvation/dehydration and show death screen

## Testing
- `node --check src/main.mjs`
- `node --check src/ui/travelConfirm.js`
- `node --check src/ui/mapUI.js`
- `node --check src/ui/deathScreen.js`
