### PR TITLE
Add encounter modal and outcome engine

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -177,7 +177,7 @@ function startGame(seedStr = '') {
     if ((prov <= 0 || wat <= 0) && !gameOver) {
       gameOver = true;
       if (mapUI) mapUI.disable();
-      if (!deathScreen) deathScreen = createDeathScreen(() => location.reload());
+      if (!deathScreen) deathScreen = createDeathScreen('You have perished.', () => location.reload());
     }
   }
 
@@ -274,7 +274,7 @@ function startGame(seedStr = '') {
         return;
       }
       const ev = queue.shift();
-      runEncounter(world, player, ev, diary.add, next);
+      runEncounter(world, player, ev, diary.add, inventory, state, next);
     };
     if (queue.length) next();
     else {

--- a/src/ui/deathScreen.js
+++ b/src/ui/deathScreen.js
@@ -1,4 +1,4 @@
-export function createDeathScreen(onRestart) {
+export function createDeathScreen(message = 'You have perished.', onRestart) {
   const overlay = document.createElement('div');
   overlay.style.position = 'absolute';
   overlay.style.left = '0';
@@ -11,6 +11,12 @@ export function createDeathScreen(onRestart) {
   overlay.style.justifyContent = 'center';
   overlay.style.alignItems = 'center';
   overlay.style.zIndex = '10000';
+
+  const msg = document.createElement('p');
+  msg.textContent = message;
+  msg.style.color = '#fff';
+  msg.style.marginBottom = '16px';
+  overlay.appendChild(msg);
 
   const btn = document.createElement('button');
   btn.textContent = 'Restart';

--- a/src/ui/encounter.js
+++ b/src/ui/encounter.js
@@ -10,11 +10,14 @@ import {
   FORTUNE,
   FLAGS
 } from '../components.js';
+import { createDeathScreen } from './deathScreen.js';
 
 let panel;
+let overlay;
 
-export function runEncounter(world, playerId, data, diaryFn, onComplete) {
+export function runEncounter(world, playerId, data, diaryFn, inventory, state, onComplete) {
   if (panel) panel.remove();
+  if (overlay) overlay.remove();
 
   const RES_MAP = {
     food: PROVISIONS,
@@ -53,6 +56,12 @@ export function runEncounter(world, playerId, data, diaryFn, onComplete) {
     for (const [k, v] of Object.entries(outcome.resources || {})) {
       modifyResource(k, v);
     }
+    for (const item of outcome.addItems || []) {
+      inventory && inventory.addItem(item);
+    }
+    for (const item of outcome.removeItems || []) {
+      inventory && inventory.removeItem(item);
+    }
     if (outcome.setFlags || outcome.clearFlags) {
       const flagRes = world.query(FLAGS).find(r => r.id === playerId);
       if (flagRes) {
@@ -61,40 +70,83 @@ export function runEncounter(world, playerId, data, diaryFn, onComplete) {
         for (const f of outcome.clearFlags || []) delete flags[f];
       }
     }
+    for (const r of outcome.recipes || []) {
+      if (state && state.recipes) state.recipes.add(r);
+    }
+    for (const w of outcome.words || []) {
+      if (state && state.lexicon) state.lexicon.add(w);
+    }
     if (outcome.diary && outcome.diaryFn) outcome.diaryFn(outcome.diary);
+
+    const flagRes2 = world.query(FLAGS).find(r => r.id === playerId);
+    const flagsNow = flagRes2 ? flagRes2.comps[0] : {};
+    let fatal = false;
+    if (flagsNow.instant_death || (outcome.setFlags || []).includes('instant_death')) {
+      fatal = true;
+    }
+    if (!fatal) {
+      for (const type of Object.values(RES_MAP)) {
+        const res = world.query(type).find(r => r.id === playerId);
+        if (res && res.comps[0].amount <= 0) { fatal = true; break; }
+      }
+    }
+
+    panel.remove();
+    overlay.remove();
+
+    if (fatal) {
+      createDeathScreen(outcome.death || 'You have perished.', () => location.reload());
+    } else if (onComplete) {
+      onComplete();
+    }
   }
+
+  overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  overlay.style.left = '0';
+  overlay.style.top = '0';
+  overlay.style.width = '100%';
+  overlay.style.height = '100%';
+  overlay.style.background = 'rgba(0,0,0,0.7)';
+  overlay.style.zIndex = '999';
+  document.body.appendChild(overlay);
 
   panel = document.createElement('div');
   panel.style.position = 'absolute';
   panel.style.left = '50%';
   panel.style.top = '50%';
   panel.style.transform = 'translate(-50%, -50%)';
-  panel.style.background = 'rgba(0, 0, 0, 0.85)';
-  panel.style.color = '#fff';
+  panel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  panel.style.backgroundSize = 'contain';
+  panel.style.backgroundRepeat = 'no-repeat';
+  panel.style.width = '1280px';
+  panel.style.height = '400px';
+  panel.style.maxWidth = '90%';
+  panel.style.display = 'flex';
+  panel.style.flexDirection = 'column';
+  panel.style.justifyContent = 'flex-end';
+  panel.style.alignItems = 'center';
   panel.style.padding = '16px';
-  panel.style.border = '2px solid #d7a13b';
-  panel.style.maxWidth = '80%';
+  panel.style.boxSizing = 'border-box';
+  panel.style.color = '#fff';
+  panel.style.fontFamily = 'serif';
   panel.style.zIndex = '1000';
 
-  const title = document.createElement('h3');
-  title.textContent = data.title || 'Encounter';
-  panel.appendChild(title);
-
-  if (data.image) {
-    const img = new Image();
-    img.src = data.image;
-    img.style.display = 'block';
-    img.style.maxWidth = '100%';
-    img.style.marginBottom = '8px';
-    panel.appendChild(img);
-  }
+  const hero = new Image();
+  hero.src = data.image || 'PASTE_URL_HERE';
+  hero.style.width = '100%';
+  hero.style.flex = '1';
+  hero.style.objectFit = 'cover';
+  hero.style.border = 'none';
+  panel.appendChild(hero);
 
   const text = document.createElement('p');
   text.textContent = data.text || '';
+  text.style.margin = '8px 0';
   panel.appendChild(text);
 
   const choices = document.createElement('div');
-  choices.style.marginTop = '8px';
+  choices.style.width = '100%';
 
   const flagRes = world.query(FLAGS).find(r => r.id === playerId);
   const playerFlags = flagRes ? flagRes.comps[0] : {};
@@ -109,12 +161,16 @@ export function runEncounter(world, playerId, data, diaryFn, onComplete) {
   opts.forEach(choice => {
     const btn = document.createElement('button');
     btn.textContent = choice.option || choice;
-    btn.style.marginRight = '6px';
+    btn.style.display = 'block';
+    btn.style.margin = '4px auto';
+    btn.style.backgroundImage = "url('PASTE_URL_HERE')";
+    btn.style.backgroundSize = 'cover';
+    btn.style.border = 'none';
+    btn.style.padding = '8px 16px';
+    btn.style.fontFamily = 'serif';
     btn.addEventListener('click', () => {
       const out = choice.outcome || {};
       applyOutcome({ ...out, diaryFn });
-      panel.remove();
-      if (onComplete) onComplete();
     });
     choices.appendChild(btn);
   });
@@ -122,9 +178,15 @@ export function runEncounter(world, playerId, data, diaryFn, onComplete) {
   if (opts.length === 0) {
     const btn = document.createElement('button');
     btn.textContent = 'Continue';
+    btn.style.display = 'block';
+    btn.style.margin = '4px auto';
+    btn.style.backgroundImage = "url('PASTE_URL_HERE')";
+    btn.style.backgroundSize = 'cover';
+    btn.style.border = 'none';
+    btn.style.padding = '8px 16px';
+    btn.style.fontFamily = 'serif';
     btn.addEventListener('click', () => {
-      panel.remove();
-      if (onComplete) onComplete();
+      applyOutcome({});
     });
     choices.appendChild(btn);
   }

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -27,6 +27,58 @@ export function createInventory(starterItems = []) {
   let offsetX = 0;
   let offsetY = 0;
 
+  function ensureCell() {
+    let cell = cells.find(c => c.children.length === 0);
+    if (!cell) {
+      cell = document.createElement('div');
+      cell.style.width = '64px';
+      cell.style.height = '64px';
+      cell.style.border = '1px solid #555';
+      cell.style.boxSizing = 'border-box';
+      cell.style.position = 'relative';
+      container.appendChild(cell);
+      cells.push(cell);
+      const rows = Math.ceil(cells.length / 6);
+      container.style.gridTemplateRows = `repeat(${rows}, 64px)`;
+    }
+    return cell;
+  }
+
+  function makeItemElement(item) {
+    const img = new Image();
+    img.src = 'PASTE_URL_HERE';
+    img.style.width = '48px';
+    img.style.height = '48px';
+    img.style.position = 'absolute';
+    img.style.left = '8px';
+    img.style.top = '8px';
+    img.dataset.item = item;
+    img.addEventListener('mousedown', ev => {
+      dragging = img;
+      offsetX = ev.offsetX + 8;
+      offsetY = ev.offsetY + 8;
+      img.style.pointerEvents = 'none';
+      document.addEventListener('mousemove', onDrag);
+      document.addEventListener('mouseup', onDrop);
+    });
+    return img;
+  }
+
+  function addItem(item) {
+    const cell = ensureCell();
+    const img = makeItemElement(item);
+    cell.appendChild(img);
+    return true;
+  }
+
+  function removeItem(item) {
+    for (const cell of cells) {
+      const img = Array.from(cell.children).find(el => el.dataset.item === item);
+      if (img) { img.remove(); return true; }
+    }
+    return false;
+  }
+
   function onDrag(ev) {
     if (!dragging) return;
     dragging.style.left = ev.pageX - offsetX + 'px';
@@ -57,26 +109,7 @@ export function createInventory(starterItems = []) {
 
 
   // populate starter items if provided
-  starterItems.forEach((item, idx) => {
-    const cell = cells[idx];
-    if (!cell) return;
-    const img = new Image();
-    img.src = 'PASTE_URL_HERE';
-    img.style.width = '48px';
-    img.style.height = '48px';
-    img.style.position = 'absolute';
-    img.style.left = '8px';
-    img.style.top = '8px';
-    img.addEventListener('mousedown', ev => {
-      dragging = img;
-      offsetX = ev.offsetX + 8;
-      offsetY = ev.offsetY + 8;
-      img.style.pointerEvents = 'none';
-      document.addEventListener('mousemove', onDrag);
-      document.addEventListener('mouseup', onDrop);
-    });
-    cell.appendChild(img);
-  });
+  starterItems.forEach(it => addItem(it));
 
   function show() {
     container.style.display = 'grid';
@@ -96,6 +129,8 @@ export function createInventory(starterItems = []) {
     show,
     hide,
     toggle,
+    addItem,
+    removeItem,
     destroy() {
       container.remove();
     }


### PR DESCRIPTION
## Summary
- implement death screen message support
- expand inventory API for item changes
- overhaul encounter modal logic with placeholder art, outcome handling, and fatal checks
- pass inventory and state to encounters and show death messages

## Testing
- `npm test` *(fails: Could not read package.json)*