### PR TITLE
Add centralized image placeholders

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,0 +1,90 @@
+export const parchmentTile = 'PASTE_URL_HERE';
+export const leatherTile = 'PASTE_URL_HERE';
+export const mapVignette = 'PASTE_URL_HERE';
+
+export const europeMap = 'PASTE_URL_HERE';
+export const nodeDefault = 'PASTE_URL_HERE';
+export const nodeCurrent = 'PASTE_URL_HERE';
+export const nodeVisited = 'PASTE_URL_HERE';
+export const marker = 'PASTE_URL_HERE';
+export const markerShadow = 'PASTE_URL_HERE';
+
+export const iconMarket = 'PASTE_URL_HERE';
+export const iconMonastery = 'PASTE_URL_HERE';
+export const iconFarmland = 'PASTE_URL_HERE';
+export const iconForest = 'PASTE_URL_HERE';
+export const iconMountain = 'PASTE_URL_HERE';
+export const iconRiver = 'PASTE_URL_HERE';
+export const iconPort = 'PASTE_URL_HERE';
+export const iconRuin = 'PASTE_URL_HERE';
+export const iconBattlefield = 'PASTE_URL_HERE';
+export const iconHiddenPath = 'PASTE_URL_HERE';
+export const iconEncampment = 'PASTE_URL_HERE';
+export const iconCathedral = 'PASTE_URL_HERE';
+
+export const btnPlank = 'PASTE_URL_HERE';
+export const tooltipPanel = 'PASTE_URL_HERE';
+export const modalFrame = 'PASTE_URL_HERE';
+export const diaryPanel = 'PASTE_URL_HERE';
+export const scorePanel = 'PASTE_URL_HERE';
+export const deathPanel = 'PASTE_URL_HERE';
+
+export const hudFoodRing = 'PASTE_URL_HERE';
+export const hudWaterRing = 'PASTE_URL_HERE';
+export const meterShadow = 'PASTE_URL_HERE';
+
+export const gridCell = 'PASTE_URL_HERE';
+export const grainSack = 'PASTE_URL_HERE';
+export const waterskin = 'PASTE_URL_HERE';
+export const toolkit = 'PASTE_URL_HERE';
+
+export const grainFieldTile = 'PASTE_URL_HERE';
+export const forestWoodTile = 'PASTE_URL_HERE';
+export const oreVeinTile = 'PASTE_URL_HERE';
+export const riverFishTile = 'PASTE_URL_HERE';
+export const scrapHeapTile = 'PASTE_URL_HERE';
+export const mosaicShardTile = 'PASTE_URL_HERE';
+
+export const heroMarket = 'PASTE_URL_HERE';
+export const heroMonastery = 'PASTE_URL_HERE';
+export const heroFarmland = 'PASTE_URL_HERE';
+export const heroForest = 'PASTE_URL_HERE';
+export const heroMountain = 'PASTE_URL_HERE';
+export const heroRiver = 'PASTE_URL_HERE';
+export const heroPort = 'PASTE_URL_HERE';
+export const heroRuin = 'PASTE_URL_HERE';
+export const heroBattlefield = 'PASTE_URL_HERE';
+export const heroHiddenPath = 'PASTE_URL_HERE';
+export const heroEncampment = 'PASTE_URL_HERE';
+export const heroCathedral = 'PASTE_URL_HERE';
+
+export const heroScribeTower = 'PASTE_URL_HERE';
+export const heroWraithVane = 'PASTE_URL_HERE';
+export const heroPlaceholder3 = 'PASTE_URL_HERE';
+export const heroPlaceholder4 = 'PASTE_URL_HERE';
+export const heroPlaceholder5 = 'PASTE_URL_HERE';
+export const heroPlaceholder6 = 'PASTE_URL_HERE';
+export const heroPlaceholder7 = 'PASTE_URL_HERE';
+export const heroPlaceholder8 = 'PASTE_URL_HERE';
+export const heroPlaceholder9 = 'PASTE_URL_HERE';
+export const heroPlaceholder10 = 'PASTE_URL_HERE';
+export const heroPlaceholder11 = 'PASTE_URL_HERE';
+export const heroPlaceholder12 = 'PASTE_URL_HERE';
+export const heroPlaceholder13 = 'PASTE_URL_HERE';
+export const heroPlaceholder14 = 'PASTE_URL_HERE';
+export const heroPlaceholder15 = 'PASTE_URL_HERE';
+export const heroPlaceholder16 = 'PASTE_URL_HERE';
+export const heroPlaceholder17 = 'PASTE_URL_HERE';
+export const heroPlaceholder18 = 'PASTE_URL_HERE';
+export const heroPlaceholder19 = 'PASTE_URL_HERE';
+export const heroPlaceholder20 = 'PASTE_URL_HERE';
+
+export const endingAzure = 'PASTE_URL_HERE';
+export const endingVert = 'PASTE_URL_HERE';
+export const endingOr = 'PASTE_URL_HERE';
+export const endingGules = 'PASTE_URL_HERE';
+export const endingSable = 'PASTE_URL_HERE';
+export const endingArgent = 'PASTE_URL_HERE';
+
+export const creditsBg = 'PASTE_URL_HERE';
+export const titleGraphic = 'PASTE_URL_HERE';

--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -1,3 +1,13 @@
+import {
+  nodeDefault as waypointUrl,
+  nodeCurrent as currentUrl,
+  nodeVisited as visitedUrl,
+  marker as markerUrl,
+  markerShadow as shadowUrl,
+  europeMap as worldMapUrl,
+  mapVignette
+} from '../assets.js';
+
 export function createRenderer(canvas) {
   const ctx = canvas.getContext('2d');
 
@@ -10,12 +20,6 @@ export function createRenderer(canvas) {
   };
 }
 
-const waypointUrl = 'PASTE_URL_HERE';
-const currentUrl = 'PASTE_URL_HERE';
-const visitedUrl = 'PASTE_URL_HERE';
-const markerUrl = 'PASTE_URL_HERE';
-const shadowUrl = 'PASTE_URL_HERE';
-const worldMapUrl = 'PASTE_URL_HERE';
 
 let waypointImg;
 let currentImg;
@@ -23,6 +27,7 @@ let visitedImg;
 let markerImg;
 let shadowImg;
 let worldMapImg;
+let vignetteImg;
 
 export function drawMap(ctx, map, playerPos = null, tween = null) {
   if (!waypointImg) {
@@ -48,6 +53,10 @@ export function drawMap(ctx, map, playerPos = null, tween = null) {
   if (!worldMapImg) {
     worldMapImg = new Image();
     worldMapImg.src = worldMapUrl;
+  }
+  if (!vignetteImg) {
+    vignetteImg = new Image();
+    vignetteImg.src = mapVignette;
   }
   if (!map) return;
 
@@ -86,17 +95,21 @@ export function drawMap(ctx, map, playerPos = null, tween = null) {
     ctx.drawImage(markerImg, baseX + 8, baseY + 8, 48, 48);
   }
 
-  // subtle radial vignette
-  const g = ctx.createRadialGradient(
-    ctx.canvas.width / 2,
-    ctx.canvas.height / 2,
-    0,
-    ctx.canvas.width / 2,
-    ctx.canvas.height / 2,
-    Math.max(ctx.canvas.width, ctx.canvas.height) / 2
-  );
-  g.addColorStop(0, 'rgba(0,0,0,0)');
-  g.addColorStop(1, 'rgba(0,0,0,0.4)');
-  ctx.fillStyle = g;
-  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  // subtle radial vignette or overlay texture
+  if (vignetteImg.complete) {
+    ctx.drawImage(vignetteImg, 0, 0, ctx.canvas.width, ctx.canvas.height);
+  } else {
+    const g = ctx.createRadialGradient(
+      ctx.canvas.width / 2,
+      ctx.canvas.height / 2,
+      0,
+      ctx.canvas.width / 2,
+      ctx.canvas.height / 2,
+      Math.max(ctx.canvas.width, ctx.canvas.height) / 2
+    );
+    g.addColorStop(0, 'rgba(0,0,0,0)');
+    g.addColorStop(1, 'rgba(0,0,0,0.4)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  }
 }

--- a/src/ui/deathScreen.js
+++ b/src/ui/deathScreen.js
@@ -1,3 +1,5 @@
+import { deathPanel } from '../assets.js';
+
 export function createDeathScreen(message = 'You have perished.', onRestart) {
   const overlay = document.createElement('div');
   overlay.style.position = 'absolute';
@@ -5,7 +7,7 @@ export function createDeathScreen(message = 'You have perished.', onRestart) {
   overlay.style.top = '0';
   overlay.style.width = '100%';
   overlay.style.height = '100%';
-  overlay.style.background = "rgba(0,0,0,0.8) url('PASTE_URL_HERE') center/cover no-repeat";
+  overlay.style.background = `rgba(0,0,0,0.8) url('${deathPanel}') center/cover no-repeat`;
   overlay.style.display = 'flex';
   overlay.style.flexDirection = 'column';
   overlay.style.justifyContent = 'center';

--- a/src/ui/diary.js
+++ b/src/ui/diary.js
@@ -1,3 +1,5 @@
+import { diaryPanel } from '../assets.js';
+
 export function createDiary(state = null) {
   const panel = document.createElement('div');
   panel.id = 'diary';
@@ -6,7 +8,7 @@ export function createDiary(state = null) {
   panel.style.top = '0';
   panel.style.width = '250px';
   panel.style.height = '100%';
-  panel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  panel.style.backgroundImage = `url('${diaryPanel}')`;
   panel.style.backgroundSize = 'cover';
   panel.style.transform = 'translateX(100%)';
   panel.style.transition = 'transform 0.3s ease-out';

--- a/src/ui/encounter.js
+++ b/src/ui/encounter.js
@@ -11,6 +11,7 @@ import {
   FLAGS
 } from '../components.js';
 import { createDeathScreen } from './deathScreen.js';
+import { modalFrame, btnPlank, heroMarket } from '../assets.js';
 
 let panel;
 let overlay;
@@ -111,7 +112,7 @@ export function runEncounter(world, playerId, data, diaryFn, inventory, state, o
   panel.style.left = '50%';
   panel.style.top = '50%';
   panel.style.transform = 'translate(-50%, -50%)';
-  panel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  panel.style.backgroundImage = `url('${modalFrame}')`;
   panel.style.backgroundSize = 'contain';
   panel.style.backgroundRepeat = 'no-repeat';
   panel.style.width = '1280px';
@@ -128,7 +129,7 @@ export function runEncounter(world, playerId, data, diaryFn, inventory, state, o
   panel.style.zIndex = '1000';
 
   const hero = new Image();
-  hero.src = data.image || 'PASTE_URL_HERE';
+  hero.src = data.image || heroMarket;
   hero.style.width = '100%';
   hero.style.flex = '1';
   hero.style.objectFit = 'cover';
@@ -158,7 +159,7 @@ export function runEncounter(world, playerId, data, diaryFn, inventory, state, o
     btn.textContent = choice.option || choice;
     btn.style.display = 'block';
     btn.style.margin = '4px auto';
-    btn.style.backgroundImage = "url('PASTE_URL_HERE')";
+    btn.style.backgroundImage = `url('${btnPlank}')`;
     btn.style.backgroundSize = 'cover';
     btn.style.border = 'none';
     btn.style.padding = '8px 16px';
@@ -175,7 +176,7 @@ export function runEncounter(world, playerId, data, diaryFn, inventory, state, o
     btn.textContent = 'Continue';
     btn.style.display = 'block';
     btn.style.margin = '4px auto';
-    btn.style.backgroundImage = "url('PASTE_URL_HERE')";
+    btn.style.backgroundImage = `url('${btnPlank}')`;
     btn.style.backgroundSize = 'cover';
     btn.style.border = 'none';
     btn.style.padding = '8px 16px';

--- a/src/ui/harvestMenu.js
+++ b/src/ui/harvestMenu.js
@@ -7,6 +7,7 @@ import {
   STAMINA,
   FORTUNE
 } from '../components.js';
+import { grainFieldTile, forestWoodTile, riverFishTile, oreVeinTile } from '../assets.js';
 
 export function createHarvestMenu(world, playerId, diaryFn = null, inventory = null) {
   const panel = document.createElement('div');
@@ -48,19 +49,19 @@ export function createHarvestMenu(world, playerId, diaryFn = null, inventory = n
 
   const SITE_DATA = {
     farm: {
-      icon: 'PASTE_URL_HERE',
+      icon: grainFieldTile,
       loot: [{ type: 'food', amount: 5 }]
     },
     forest: {
-      icon: 'PASTE_URL_HERE',
+      icon: forestWoodTile,
       loot: [{ type: 'wood', amount: 5 }]
     },
     river: {
-      icon: 'PASTE_URL_HERE',
+      icon: riverFishTile,
       loot: [{ type: 'water', amount: 5 }]
     },
     mine: {
-      icon: 'PASTE_URL_HERE',
+      icon: oreVeinTile,
       loot: [{ type: 'iron', amount: 3 }]
     }
   };

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -1,11 +1,10 @@
 import { PROVISIONS, WATER, GEAR, FORTUNE } from '../components.js';
+import { hudFoodRing as foodUrl, hudWaterRing as waterUrl } from '../assets.js';
 
 // Placeholder icons for stats not yet backed by real assets
 const healthIcon = '❤';
 const staminaIcon = '⚡';
 
-const foodUrl = 'PASTE_URL_HERE';
-const waterUrl = 'PASTE_URL_HERE';
 
 let foodImg;
 let waterImg;

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -1,8 +1,12 @@
+import { gridCell, grainSack, waterskin, toolkit, leatherTile } from '../assets.js';
+
 export function createInventory(starterItems = []) {
   const container = document.createElement('div');
   container.style.position = 'absolute';
   container.style.right = '10px';
   container.style.bottom = '10px';
+  container.style.backgroundImage = `url('${leatherTile}')`;
+  container.style.backgroundSize = '64px 64px';
   // Hidden by default; show() will switch display back to grid
   container.style.display = 'none';
   container.style.gridTemplateColumns = 'repeat(6, 64px)';
@@ -19,6 +23,8 @@ export function createInventory(starterItems = []) {
     cell.style.border = '1px solid #555';
     cell.style.boxSizing = 'border-box';
     cell.style.position = 'relative';
+    cell.style.backgroundImage = `url('${gridCell}')`;
+    cell.style.backgroundSize = 'cover';
     container.appendChild(cell);
     cells.push(cell);
   }
@@ -36,6 +42,8 @@ export function createInventory(starterItems = []) {
       cell.style.border = '1px solid #555';
       cell.style.boxSizing = 'border-box';
       cell.style.position = 'relative';
+      cell.style.backgroundImage = `url('${gridCell}')`;
+      cell.style.backgroundSize = 'cover';
       container.appendChild(cell);
       cells.push(cell);
       const rows = Math.ceil(cells.length / 6);
@@ -46,7 +54,12 @@ export function createInventory(starterItems = []) {
 
   function makeItemElement(item) {
     const img = new Image();
-    img.src = 'PASTE_URL_HERE';
+    const ITEM_MAP = {
+      grain_sack: grainSack,
+      waterskin: waterskin,
+      toolkit: toolkit
+    };
+    img.src = ITEM_MAP[item] || 'PASTE_URL_HERE';
     img.style.width = '48px';
     img.style.height = '48px';
     img.style.position = 'absolute';

--- a/src/ui/mapUI.js
+++ b/src/ui/mapUI.js
@@ -1,10 +1,11 @@
 import { POSITION } from '../components.js';
+import { tooltipPanel } from '../assets.js';
 
 export function createMapUI(canvas, mapData, world, playerId, onSelect, costFn) {
   const overlay = document.createElement('div');
   overlay.style.position = 'absolute';
   overlay.style.pointerEvents = 'none';
-  overlay.style.background = 'rgba(216, 199, 158, 0.95)';
+  overlay.style.background = `url('${tooltipPanel}') no-repeat center/contain`;
   overlay.style.color = '#000';
   overlay.style.padding = '4px 6px';
   overlay.style.font = '12px sans-serif';

--- a/src/ui/titleScreen.js
+++ b/src/ui/titleScreen.js
@@ -1,3 +1,5 @@
+import { parchmentTile, tooltipPanel, btnPlank, titleGraphic } from '../assets.js';
+
 export function createTitleScreen(onRide) {
   const overlay = document.createElement('div');
   overlay.style.position = 'absolute';
@@ -5,7 +7,7 @@ export function createTitleScreen(onRide) {
   overlay.style.top = '0';
   overlay.style.width = '100%';
   overlay.style.height = '100%';
-  overlay.style.backgroundImage = "url('PASTE_URL_HERE')";
+  overlay.style.backgroundImage = `url('${parchmentTile}')`;
   overlay.style.backgroundSize = 'cover';
   overlay.style.display = 'flex';
   overlay.style.flexDirection = 'column';
@@ -16,12 +18,13 @@ export function createTitleScreen(onRide) {
   overlay.style.transition = 'opacity 0.5s';
 
   const titleImg = new Image();
-  titleImg.src = 'PASTE_URL_HERE';
+  titleImg.src = titleGraphic;
   titleImg.style.marginBottom = '16px';
   overlay.appendChild(titleImg);
 
   const beginBtn = document.createElement('button');
   beginBtn.textContent = 'Begin Journey';
+  beginBtn.style.backgroundImage = `url('${btnPlank}')`;
   beginBtn.style.transition = 'filter 0.2s';
   beginBtn.addEventListener('mouseover', () => {
     beginBtn.style.filter = 'brightness(1.2)';
@@ -35,7 +38,7 @@ export function createTitleScreen(onRide) {
   seedPanel.style.left = '50%';
   seedPanel.style.top = '50%';
   seedPanel.style.transform = 'translate(-50%, -50%)';
-  seedPanel.style.backgroundImage = "url('PASTE_URL_HERE')";
+  seedPanel.style.backgroundImage = `url('${tooltipPanel}')`;
   seedPanel.style.backgroundSize = 'cover';
   seedPanel.style.padding = '16px';
   seedPanel.style.display = 'none';
@@ -48,6 +51,7 @@ export function createTitleScreen(onRide) {
 
   const rideBtn = document.createElement('button');
   rideBtn.textContent = 'Ride';
+  rideBtn.style.backgroundImage = `url('${btnPlank}')`;
   rideBtn.addEventListener('click', () => {
     const seed = seedInput.value.trim();
     overlay.style.opacity = '0';

--- a/src/ui/travelConfirm.js
+++ b/src/ui/travelConfirm.js
@@ -1,9 +1,11 @@
+import { scorePanel } from '../assets.js';
+
 export function createTravelConfirm() {
   const panel = document.createElement('div');
   panel.style.position = 'absolute';
   panel.style.right = '10px';
   panel.style.bottom = '10px';
-  panel.style.background = "url('PASTE_URL_HERE') no-repeat center/contain";
+  panel.style.background = `url('${scorePanel}') no-repeat center/contain`;
   panel.style.color = '#fff';
   panel.style.padding = '8px';
   panel.style.border = '2px solid #d7a13b';


### PR DESCRIPTION
## Summary
- centralize all image URL placeholders in `assets.js`
- import image placeholders across UI modules
- update renderer to load map vignette overlay
- use placeholders for HUD, encounters, inventory, and other panels

## Testing
- `node --check src/ui/hud.js`
- `node --check src/engine/renderer.js`
- `find src -name '*.js' | xargs -I{} node --check {}`