### PR TITLE
Generic icon locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Pilgrim Outbound  
-*A zero-dependency browser roguelike set in 9ᵗʰ-century Europe*
+*A zero-dependency browser roguelike set in a mythic age*
 
 
 ---
 
 ## Setting  
-AD 879.  Charlemagne’s empire has splintered, Viking longships menace every coast, and rumors of a coming plague drift on the trade winds.  
-You are a battered royal courier who wakes in the aftermath of a raid, hundreds of leagues from home, holding a relic that could decide the fate of a kingdom.  With only a weary mount, a torn map, and a half-empty saddlebag, you must thread the fractured realms of Christendom, the pagan North, and the Muslim frontier to deliver your charge—or die unknown along the road.
+A great empire has splintered, sea raiders menace every coast, and rumors of plague drift on the trade winds.
+You are a battered royal courier who wakes in the aftermath of a raid, far from home, holding a relic that could decide the fate of a kingdom. With only a weary mount, a torn map, and a half-empty saddlebag, you must thread rival realms and warring frontiers to deliver your charge—or die unknown along the road.
 
 ---
 
@@ -72,9 +72,9 @@ Stick to them unless we explicitly change the baseline in a future PR.
 ---
 
 ## Endgame Paths (When Complete)  
-1. **Azure – Pax Romana**: escort the relic to Rome and secure papal sanction.  
+1. **Azure – Pax Romana**: escort the relic to the grand cathedral and secure high sanction.
 2. **Vert – Seed of Yggdrasil**: ally with a Norse skald to plant a holy oak on pagan soil.  
-3. **Or – House of Wisdom**: ferry four scholars to Córdoba to spark a new renaissance.  
+3. **Or – House of Wisdom**: ferry four scholars to a distant library to spark a new renaissance.
 4. **Gules – The Red Cross**: raise a refugee banner and break a siege.  
 5. **Sable – The Black Plague**: venture into a quarantined city bearing a legendary cure—or join the darkness.  
 6. **Argent – Homecoming**: thread treacherous borders to lay the relic at a dying king’s bedside.

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -554,7 +554,7 @@
     {
       "id": "star_yew_orchard",
       "weight": 5,
-      "text": "An orchard of yews cut into star shapes; sap glitters like gold dust. A blind woman tends them, insisting each tree remembers Rome.",
+      "text": "An orchard of yews cut into star shapes; sap glitters like gold dust. A blind woman tends them, insisting each tree remembers a fallen empire.",
       "options": [
         {
           "option": "Tap sap into vials",

--- a/data/map.json
+++ b/data/map.json
@@ -1,15 +1,15 @@
 {
   "waypoints": [
     {
-      "name": "Prague",
+      "name": "Market Town",
       "coords": [
         0,
         0
       ],
       "type": "market",
       "neighbors": [
-        "Vienna",
-        "Nuremberg"
+        "Market City",
+        "Farmland"
       ],
       "travelCosts": {
         "food": 2,
@@ -19,14 +19,14 @@
       "tags": ["safe camp"]
     },
     {
-      "name": "Vienna",
+      "name": "Market City",
       "coords": [
         5,
         -3
       ],
       "neighbors": [
-        "Prague",
-        "Venice"
+        "Market Town",
+        "Port"
       ],
       "travelCosts": {
         "food": 3,
@@ -37,14 +37,14 @@
       "tags": []
     },
     {
-      "name": "Nuremberg",
+      "name": "Farmland",
       "coords": [
         -2,
         1
       ],
       "type": "farmland",
       "neighbors": [
-        "Prague"
+        "Market Town"
       ],
       "travelCosts": {
         "food": 2,
@@ -54,13 +54,13 @@
       "tags": ["shortcut"]
     },
     {
-      "name": "Venice",
+      "name": "Port",
       "coords": [
         7,
         -8
       ],
       "neighbors": [
-        "Vienna"
+        "Market City"
       ],
       "travelCosts": {
         "food": 4,
@@ -71,13 +71,13 @@
       "tags": ["coastal"]
     },
     {
-      "name": "Rome",
+      "name": "Grand Cathedral",
       "coords": [
         8,
         -6
       ],
       "neighbors": [
-        "Vienna"
+        "Market City"
       ],
       "travelCosts": {
         "food": 4,

--- a/src/assets.js
+++ b/src/assets.js
@@ -2,7 +2,7 @@ export const parchmentTile = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-
 export const leatherTile = 'PASTE_URL_HERE';
 export const mapVignette = 'PASTE_URL_HERE';
 
-export const europeMap = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-9e387411d153/ChatGPT%20Image%20May%2027%2C%202025%2C%2001_55_50%20PM.png?v=1748368562677';
+export const worldMap = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-9e387411d153/ChatGPT%20Image%20May%2027%2C%202025%2C%2001_55_50%20PM.png?v=1748368562677';
 export const nodeDefault = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-9e387411d153/ChatGPT%20Image%20May%2027%2C%202025%2C%2009_19_11%20AM.png?v=1748367014349';
 export const nodeCurrent = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-9e387411d153/ChatGPT%20Image%20May%2027%2C%202025%2C%2009_21_24%20AM.png?v=1748367018581';
 export const nodeVisited = 'https://cdn.glitch.global/926b1852-0bd6-415e-8777-9e387411d153/ChatGPT%20Image%20May%2027%2C%202025%2C%2009_20_40%20AM.png?v=1748367016509';

--- a/src/engine/renderer.js
+++ b/src/engine/renderer.js
@@ -4,7 +4,7 @@ import {
   nodeVisited as visitedUrl,
   marker as markerUrl,
   markerShadow as shadowUrl,
-  europeMap as worldMapUrl,
+  worldMap as worldMapUrl,
   mapVignette,
   iconMarket,
   iconMonastery,

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -253,8 +253,8 @@ function startGame(seedStr = '') {
       markerTween = { start: startPos, end: { x, y }, t: 0, dur: 500 };
     }
 
-    if (wp.name === 'Rome') {
-      alert('Victory! You reached Rome.');
+    if (wp.tags && wp.tags.includes('legend_marker')) {
+      alert('Victory! You reached the final landmark.');
       if (mapUI) mapUI.disable();
     }
 


### PR DESCRIPTION
## Summary
- rename europeMap asset to worldMap
- remove real place names from the map and README
- trigger victory when reaching any `legend_marker` node
- update encounters text to avoid naming real locations

## Testing
- `node -v`